### PR TITLE
remove colour assignment for 'Normal'

### DIFF
--- a/colors/eldar.vim
+++ b/colors/eldar.vim
@@ -84,7 +84,6 @@ let s:ColourAssignment = {}
 
 " Editor settings
 " ---------------
-let  s:ColourAssignment['Normal']        =  {'GUIFG':  'White',     'GUIBG':  'Black'}
 let  s:ColourAssignment['Cursor']        =  {'GUI':    'Reverse'}
 let  s:ColourAssignment['CursorLine']    =  {'GUI':    'NONE',      'GUIBG':  'Black'}
 let  s:ColourAssignment['LineNr']        =  {'GUIFG':  'DarkGray'}


### PR DESCRIPTION
Fixed a bug where the background color changed to gray in bash v4.3.46.